### PR TITLE
Refactor: rename params and variables

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,30 @@
+# Sanity checks
+name: "sanity"
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build-demo-app:
+    name: 'Build demo, run demo'
+    strategy:
+      fail-fast: false
+      # Run on Linux
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v3
+
+      - name: 'Build and run demo app'
+        run: |
+          set -euxo pipefail
+          cd ${{ github.workspace }}/
+          make test_tinyp256
+          res="$(./test_tinyp256)"
+          [[ "$res" == "Signature is good" ]] || exit 1

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ The API contains only one function
  *         returns TINYP256_FAIL if an error occurred or the signature is
  *         invalid
  *
- * @param pk IN -- ECDSA-P256 public key. Must point to a 64-byte buffer
+ * @param pubkey IN -- ECDSA-P256 public key. Must point to a 64-byte buffer
  * containing an uncompressed point in affine coordinates (Qx, Qy)
- * @param pk_len IN -- Size of public key buffer in bytes. Must be 64.
- * @param sha256 IN -- The SHA-256 digest of the message to verify. Must point to a 32-byte buffer.
- * @param sha256_len IN -- Size of SHA-256 digest buffer in bytes. Must be 32.
- * @param sig IN -- ECDSA-P256 signature value. Must point to a 64-byte buffer
+ * @param pubkey_len IN -- Size of public key buffer in bytes. Must be 64.
+ * @param digest IN -- The SHA-256 digest of the message to verify. Must point to a 32-byte buffer.
+ * @param digest_len IN -- Size of SHA-256 digest buffer in bytes. Must be 32.
+ * @param signature IN -- ECDSA-P256 signature value. Must point to a 64-byte buffer
  * containing the raw (r, s) value
- * @param sig_len IN -- Size of sig buffer in bytes. Must be 64.
+ * @param signature_len IN -- Size of sig buffer in bytes. Must be 64.
  *
  */
 tinyp256_t tinyp256_verify(
-    const uint8_t *pk, uint16_t pk_len,
-    uint8_t *sha256, uint16_t sha256_len,
-    uint8_t *sig, uint16_t sig_len);
+    const uint8_t *pubkey, uint16_t pubkey_len,
+    uint8_t *digest, uint16_t digest_len,
+    uint8_t *signature, uint16_t signature_len);
 ```
 
 ## Interoperate with OpenSSL

--- a/test_tinyp256.c
+++ b/test_tinyp256.c
@@ -2,11 +2,12 @@
 #include <stdio.h>
 #include "tinyp256.h"
 
+// Keygen:
 // openssl ecparam -name prime256v1 -genkey -out private.pem
 // openssl ec -in private.pem -pubout > public.pem
 
 // openssl ec -pubin -in public.pem -outform DER  2> /dev/null | xxd -i -s 27
-uint8_t pub[64] = {
+uint8_t pubkey[64] = {
     0x36, 0x8e, 0xd4, 0x01, 0x0d, 0x11, 0x85, 0x0b,
     0xa6, 0x87, 0xb8, 0x87, 0x34, 0x5a, 0x6c, 0x26,
     0x98, 0x52, 0x59, 0xd7, 0xc2, 0x6f, 0x48, 0xab,
@@ -17,8 +18,7 @@ uint8_t pub[64] = {
     0x12, 0x11, 0x45, 0xd4, 0x5e, 0x86, 0x45, 0x4c
 };
 
-// openssl dgst -sha256 -binary msg.txt > msg.sha256.bin
-// xxd -i msg.sha256.bin
+// openssl dgst -sha256 -binary msg.bin | xxd -i
 uint8_t digest[32] = {
     0x91, 0x75, 0x1c, 0xee, 0x0a, 0x1a, 0xb8, 0x41,
     0x44, 0x00, 0x23, 0x8a, 0x76, 0x14, 0x11, 0xda,
@@ -26,7 +26,7 @@ uint8_t digest[32] = {
     0xa9, 0x16, 0x49, 0xe2, 0x5b, 0xe5, 0x3a, 0xda
 };
 
-// openssl pkeyutl -sign -inkey private.pem -in msg.sha256.bin > msg.sig.bin
+// openssl dgst -sha256 -sign private.pem -out msg.sig.bin msg.bin
 // openssl asn1parse -in msg.sig.bin -inform DER | awk -F':' '{print $4}' | awk 'NF > 0' | xxd -r -p | xxd -i
 uint8_t signature[64] = {
     // r
@@ -42,7 +42,7 @@ uint8_t signature[64] = {
 };
 
 int main(void) {
-    if (tinyp256_verify(pub, sizeof(pub), digest, sizeof(digest), signature, sizeof(signature)) == TINYP256_OK) {
+    if (tinyp256_verify(pubkey, sizeof(pubkey), digest, sizeof(digest), signature, sizeof(signature)) == TINYP256_OK) {
         printf("Signature is good\n");
         return 0;
     } else {

--- a/tinyp256.c
+++ b/tinyp256.c
@@ -4,26 +4,26 @@
 #include "tinyp256.h"
 
 tinyp256_t tinyp256_verify(
-    const uint8_t *pk, uint16_t pk_len,
-    uint8_t *sha256, uint16_t sha256_len,
-    uint8_t *sig, uint16_t sig_len)
+    const uint8_t *pubkey, uint16_t pubkey_len,
+    uint8_t *digest, uint16_t digest_len,
+    uint8_t *signature, uint16_t signature_len)
 {
     const struct uECC_Curve_t * curve = uECC_secp256r1();
-    if (pk_len != 64) {
+    if (pubkey_len != 64) {
         return TINYP256_FAIL;
     }
 
-    if (sha256_len != 32) {
+    if (digest_len != 32) {
         return TINYP256_FAIL;
     }
 
-    if (sig_len != 64) {
+    if (signature_len != 64) {
         return TINYP256_FAIL;
     }
-    if (uECC_valid_public_key(pk, curve) != 0) {
+    if (uECC_valid_public_key(pubkey, curve) != 0) {
         return TINYP256_FAIL;
     }
 
-    return ( uECC_verify(pk, sha256, sha256_len, sig, curve) == 1 ?
+    return ( uECC_verify(pubkey, digest, digest_len, signature, curve) == 1 ?
         TINYP256_OK : TINYP256_FAIL );
 }

--- a/tinyp256.h
+++ b/tinyp256.h
@@ -20,18 +20,20 @@ typedef enum {
  *         returns TINYP256_FAIL if an error occurred or the signature is
  *         invalid
  *
- * @param pk IN -- ECDSA-P256 public key. Must point to a 64-byte buffer.
- * @param pk_len IN -- Size of public key buffer in bytes. Must be 64.
- * @param sha256 IN -- The SHA-256 digest of the message to sign. Must point to a 32-byte buffer.
- * @param sha256_len IN -- Size of SHA-256 digest buffer in bytes. Must be 32.
- * @param sig IN -- ECDSA-P256 signature value. Must point to a 64-byte buffer.
- * @param sig_len IN -- Size of sig buffer in bytes. Must be 64.
+ * @param pubkey IN -- ECDSA-P256 public key. Must point to a 64-byte buffer
+ * containing an uncompressed point in affine coordinates (Qx, Qy)
+ * @param pubkey_len IN -- Size of public key buffer in bytes. Must be 64.
+ * @param digest IN -- The SHA-256 digest of the message to verify. Must point to a 32-byte buffer.
+ * @param digest_len IN -- Size of SHA-256 digest buffer in bytes. Must be 32.
+ * @param signature IN -- ECDSA-P256 signature value. Must point to a 64-byte buffer
+ * containing the raw (r, s) value
+ * @param signature_len IN -- Size of sig buffer in bytes. Must be 64.
  *
  */
 tinyp256_t tinyp256_verify(
-    const uint8_t *pk, uint16_t pk_len,
-    uint8_t *sha256, uint16_t sha256_len,
-    uint8_t *sig, uint16_t sig_len);
+    const uint8_t *pubkey, uint16_t pubkey_len,
+    uint8_t *digest, uint16_t digest_len,
+    uint8_t *signature, uint16_t signature_len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Rename a few variables and parameters in code for better consistency with documentation, and better comprehension of the `test_tinyp256.c` demo app.

- Add a sanity check GHA workflow in CI.