### PR TITLE
Crosscheck: verify openssl generated test vectors

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -28,3 +28,24 @@ jobs:
           make test_tinyp256
           res="$(./test_tinyp256)"
           [[ "$res" == "Signature is good" ]] || exit 1
+
+  cross-check-with-openssl:
+    name: 'Cross check with OpenSSL'
+    strategy:
+      fail-fast: false
+      # Run on Linux
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v3
+
+      - name: 'Verify randomly generated test vectors'
+        run: |
+          set -euxo pipefail
+          cd ${{ github.workspace }}/
+          for i in {1..42}; do
+            echo "Testing (round $i):"
+            ./scripts/openssl-crosscheck.sh
+          done

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+# Application source
+APP_SRC ?= test_tinyp256.c
+
 # For Linux or any machines with gcc compiler
-CC = gcc
+CC ?= gcc
 
 # For Linux
-CFLAGS:=-Os -std=c99 -Wall -Wextra -D_ISOC99_SOURCE -MMD -I.
+CFLAGS := -Os -std=c99 -Wall -Wextra -D_ISOC99_SOURCE -MMD -I.
+
 
 SRC = tinyp256.c ecc.c ecc_dsa.c
 
@@ -13,8 +17,8 @@ OBJ = $(SRC:.c=.o)
 
 all: test_tinyp256
 
-test_tinyp256: test_tinyp256.o $(OBJ)
-	$(CC) $(CFLAGS) $(OBJ) test_tinyp256.o \
+test_tinyp256: $(basename $(APP_SRC)).o $(OBJ)
+	$(CC) $(CFLAGS) $(OBJ) $(basename $(APP_SRC)).o \
 		-o test_tinyp256
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -72,22 +72,22 @@ tinyp256_t tinyp256_verify(
 
 ### Signature verification with tinyp256
 
-Obtain C-styled bytes arrays pointed to by `pk`, `sha256` and `sig` as follows.
-Feed `tinyp256_verify()` with them for signature verification.
+Obtain C-styled bytes arrays pointed to by `pubkey`, `digest` and `signature` as
+follows.  Feed `tinyp256_verify()` with them for signature verification.
 
-- Public key (`pk`)
+- Public key (`pubkey`)
 
   ```bash
   openssl ec -pubin -in public.pem -outform DER  2>/dev/null | xxd -i -s 27
   ```
 
-- SHA-256 hash digest (`sha256`) of message to verify
+- SHA-256 hash digest (`digest`) of message to verify
 
   ```bash
   openssl dgst -sha256 -binary msg.bin | xxd -i
   ```
 
-- Signature (`sig`)
+- Signature (`signature`)
 
   ```bash
   openssl asn1parse -in msg.sig.bin -inform DER \
@@ -97,7 +97,7 @@ Feed `tinyp256_verify()` with them for signature verification.
     | xxd -i
   ```
 
-Sample byte arrays `pk`, `sha256` and `sig` can be found in
+Sample byte arrays `pubkey`, `digest` and `signature` can be found in
 [test_tinyp256.c](./test_tinyp256.c). To test, in repository's directory root
 
 ```bash

--- a/scripts/openssl-crosscheck.sh
+++ b/scripts/openssl-crosscheck.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Test openssl-generated test vector with tinyp256
+#
+set -euxo pipefail
+
+SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
+
+PRIKEY_FILE="$(mktemp)"
+readonly PRIKEY_FILE
+
+PUBKEY_FILE="$(mktemp)"
+readonly PUBKEY_FILE
+
+PAYLOAD_FILE="$(mktemp)"
+readonly PAYLOAD_FILE
+
+SIGNATURE_FILE="$(mktemp)"
+readonly SIGNATURE_FILE
+
+TEST_APP_FILE="$SCRIPT_DIR/../__tmp_test.c"
+readonly TEST_APP_FILE
+
+########################################
+# Generate a test vector using openssl
+#
+# Keygen
+openssl ecparam -name prime256v1 -genkey -noout -out "$PRIKEY_FILE"
+openssl ec -in "$PRIKEY_FILE" -pubout -out "$PUBKEY_FILE"
+# Create random payload and sign it
+head -c 4096 /dev/urandom > "$PAYLOAD_FILE"
+openssl dgst -sha256 -sign "$PRIKEY_FILE" -out "$SIGNATURE_FILE" "$PAYLOAD_FILE"
+
+PUBKEY="$(openssl ec -pubin -in "$PUBKEY_FILE" -outform DER  2>/dev/null \
+  | xxd -i -s 27)"
+DIGEST="$(openssl dgst -sha256 -binary "$PAYLOAD_FILE" | xxd -i)"
+SIGNATURE="$(openssl asn1parse -in "$SIGNATURE_FILE" -inform DER \
+  | awk -F':' '{print $4}' \
+  | awk 'NF > 0' \
+  | xxd -r -p \
+  | xxd -i)"
+
+
+################################################
+# Create test application containing test vector
+#
+cat <<EOF >"$TEST_APP_FILE"
+#include <stdint.h>
+#include <stdio.h>
+#include "tinyp256.h"
+
+uint8_t pubkey[64] = {
+$PUBKEY
+};
+
+uint8_t digest[32] = {
+$DIGEST
+};
+
+uint8_t signature[64] = {
+$SIGNATURE
+};
+
+int main(void) {
+    if (tinyp256_verify(pubkey, sizeof(pubkey), digest, sizeof(digest), signature, sizeof(signature)) == TINYP256_OK) {
+        printf("Signature is good\n");
+        return 0;
+    } else {
+        printf("Signature is bad\n");
+        return 1;
+    }
+}
+EOF
+
+############################################
+# Build test app and test
+#
+make clean
+make APP_SRC="$TEST_APP_FILE"
+res="$("$SCRIPT_DIR"/../test_tinyp256)"
+[[ "$res" == "Signature is good" ]] || exit 1


### PR DESCRIPTION
- Use OpenSSL to generate a test vector, and use it in a test application for verification with tinyp256.
- Add 42 rounds of this test in GHA CI.
- Update README.md.