### PR TITLE
fix: signature extraction command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ follows.  Feed `tinyp256_verify()` with them for signature verification.
   openssl asn1parse -in msg.sig.bin -inform DER \
     | awk -F':' '{print $4}' \
     | awk 'NF > 0' \
+    | awk '{printf "%064s", $0}' \
+    | tr ' ' 0 \
     | xxd -r -p \
     | xxd -i
   ```
+
+  Note that we need to pad the `r`, `s` values in hex with leading zeros so that
+  they are 32-byte long, if needed - that's what `awk '{printf "%064s", $0} | tr
+  ' ' 0` is for.
 
 Sample byte arrays `pubkey`, `digest` and `signature` can be found in
 [test_tinyp256.c](./test_tinyp256.c). To test, in repository's directory root

--- a/scripts/openssl-crosscheck.sh
+++ b/scripts/openssl-crosscheck.sh
@@ -32,12 +32,20 @@ openssl ec -in "$PRIKEY_FILE" -pubout -out "$PUBKEY_FILE"
 head -c 4096 /dev/urandom > "$PAYLOAD_FILE"
 openssl dgst -sha256 -sign "$PRIKEY_FILE" -out "$SIGNATURE_FILE" "$PAYLOAD_FILE"
 
+# For debugging
+openssl ec -pubin -in "$PUBKEY_FILE" -text -noout >&2
+openssl asn1parse -in "$SIGNATURE_FILE" -inform DER >&2
+
+# Convert to tinyp256 required data format
 PUBKEY="$(openssl ec -pubin -in "$PUBKEY_FILE" -outform DER  2>/dev/null \
   | xxd -i -s 27)"
 DIGEST="$(openssl dgst -sha256 -binary "$PAYLOAD_FILE" | xxd -i)"
+# Pad r, s hex strings with leading 0s so that they are 32 bytes, if needed
 SIGNATURE="$(openssl asn1parse -in "$SIGNATURE_FILE" -inform DER \
   | awk -F':' '{print $4}' \
   | awk 'NF > 0' \
+  | awk '{printf "%064s", $0}' \
+  | tr ' ' 0 \
   | xxd -r -p \
   | xxd -i)"
 

--- a/scripts/openssl-crosscheck.sh
+++ b/scripts/openssl-crosscheck.sh
@@ -36,6 +36,11 @@ openssl dgst -sha256 -sign "$PRIKEY_FILE" -out "$SIGNATURE_FILE" "$PAYLOAD_FILE"
 openssl ec -pubin -in "$PUBKEY_FILE" -text -noout >&2
 openssl asn1parse -in "$SIGNATURE_FILE" -inform DER >&2
 
+# Self-test: verify signature with openssl
+# This also mitigates fault injection attacks
+openssl dgst -verify "$PUBKEY_FILE" -keyform PEM -sha256 \
+  -signature "$SIGNATURE_FILE" -binary "$PAYLOAD_FILE"
+
 # Convert to tinyp256 required data format
 PUBKEY="$(openssl ec -pubin -in "$PUBKEY_FILE" -outform DER  2>/dev/null \
   | xxd -i -s 27)"


### PR DESCRIPTION
Fix a bug in command to extract raw (r, s) values from DER encoded signature. We need to pad the hex strings for r and s with leading 0s if needed, so that they are 32 bytes in binary.